### PR TITLE
fix(github_integration): circumvent stargazers not accessible

### DIFF
--- a/src/best_of/integrations/github_integration.py
+++ b/src/best_of/integrations/github_integration.py
@@ -133,9 +133,7 @@ query($owner: String!, $repo: String!, $since_recent_activity: GitTimestamp!) {
     licenseInfo {
       spdxId
     }
-    stargazers {
-      totalCount
-    }
+    stargazerCount
     pullRequests {
       totalCount
     }
@@ -217,6 +215,9 @@ query($owner: String!, $repo: String!, $since_recent_activity: GitTimestamp!) {
             )
             return None
         response_data = response.json()
+
+        if response_data.get("errors"):
+            log.warning(f"Request returned with errors: {response_data['errors']}")
 
         if "data" not in response_data:
             log.info("Request returned unexpected data: " + str(response_data))
@@ -388,8 +389,8 @@ def update_via_github_api(project_info: Dict) -> None:
             # always use the highest number
             project_info.closed_issue_count = closed_issue_count
 
-    if github_info.stargazers and github_info.stargazers.totalCount:
-        star_count = int(github_info.stargazers.totalCount)
+    if github_info.stargazerCount:
+        star_count = int(github_info.stargazerCount)
         if not project_info.star_count:
             project_info.star_count = star_count
         elif int(project_info.star_count) < star_count:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include [WIP] within the title. -->

Circumvent the following error occurred in https://github.com/YDX-2147483647/best-of-bits/pull/417#issuecomment-5082384289 and reported in https://github.com/orgs/community/discussions/202883.

```python
{
    "data": {"repository": None},
    "errors": [
        {
            "type": "FORBIDDEN",
            "path": ["repository", "stargazers"],
            "extensions": {"saml_failure": False},
            "locations": [{"line": 19, "column": 5}],
            "message": "Resource not accessible by integration",
        }
    ],
}
```

The workaround is to replace `stargazers.totalCount` with `stargazerCount`.


Confirmed in https://github.com/YDX-2147483647/best-of-bits/pull/418.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of-generator/blob/main/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
